### PR TITLE
Add full support for dm96xx

### DIFF
--- a/arch/arm/dts/exynos4412-itop4412.dts
+++ b/arch/arm/dts/exynos4412-itop4412.dts
@@ -26,78 +26,9 @@
 		i2c7 = "/i2c@138d0000";
 		serial0 = "/serial@13820000";
 		console = "/serial@13820000";
-		mmc0 = &mshc_0;    /* MMC */
-		mmc1 = &sdhci2;    /* TF card */
+		mmc2 = "sdhci@12530000";    /* TF card */
+		mmc4 = "dwmmc@12550000";    /* eMMC */
 	};
-
-#if 0
-	fimd@11c00000 {
-		compatible = "samsung,exynos-fimd";
-		reg = <0x11c00000 0xa4>;
-
-		samsung,vl-freq = <60>;
-		samsung,vl-col = <480>;
-		samsung,vl-row = <272>;
-		samsung,vl-width = <480>;
-		samsung,vl-height = <272>;
-
-		samsung,vl-clkp = <0>;
-		samsung,vl-oep = <0>;
-		samsung,vl-hsp = <1>;
-		samsung,vl-vsp = <0>;
-		samsung,vl-dp = <1>;
-		samsung,vl-bpix = <4>;
-
-		samsung,vl-hspw = <32>;
-		samsung,vl-hbpd = <80>;
-		samsung,vl-hfpd = <48>;
-		samsung,vl-vspw = <2>;
-		samsung,vl-vbpd = <1>;
-		samsung,vl-vfpd = <13>;
-		samsung,vl-cmd-allow-len = <0xf>;
-
-		samsung,winid = <0>;
-		samsung,power-on-delay = <30>;
-		samsung,interface-mode = <1>;
-		samsung,mipi-enabled = <0>;
-		//samsung,dp-enabled;
-		//samsung,dual-lcd-enabled;
-
-		samsung,logo-on = <1>;
-		samsung,resolution = <0>;
-		samsung,rgb-mode = <1>;
-		samsung,pwm-out-gpio  = <&gpd0 1 1>;
-		samsung,bl-en-gpio = <&gpd0 0 1>;
-	};
-
-	mipidsi@11c80000 {
-		compatible = "samsung,exynos-mipi-dsi";
-		reg = <0x11c80000 0x5c>;
-
-		samsung,dsim-config-e-interface = <1>;
-		samsung,dsim-config-e-virtual-ch = <0>;
-		samsung,dsim-config-e-pixel-format = <7>;
-		samsung,dsim-config-e-burst-mode = <1>;
-		samsung,dsim-config-e-no-data-lane = <3>;
-		samsung,dsim-config-e-byte-clk = <0>;
-		samsung,dsim-config-hfp = <1>;
-
-		samsung,dsim-config-p = <3>;
-		samsung,dsim-config-m = <120>;
-		samsung,dsim-config-s = <1>;
-
-		samsung,dsim-config-pll-stable-time = <500>;
-		samsung,dsim-config-esc-clk = <20000000>;
-		samsung,dsim-config-stop-holding-cnt = <0x7ff>;
-		samsung,dsim-config-bta-timeout = <0xff>;
-		samsung,dsim-config-rx-timeout = <0xffff>;
-
-		samsung,dsim-device-id = <0xffffffff>;
-		samsung,dsim-device-bus-id = <0>;
-
-		samsung,dsim-device-reverse-panel = <1>;
-	};
-#endif
 
 	i2c@13860000 {
 		samsung,i2c-sda-delay = <100>;
@@ -111,16 +42,36 @@
 			reg = <0x09 0 0>;
 			#clock-cells = <1>;
 
-            /* TODO: need detail info? */
+			/* TODO: need detail info? */
 		};
 	};
 
-    /* UART2 */
+	/* UART2 */
 	serial@13820000 {
 		status = "okay";
 	};
 
-    /* USB 2.0 Host Controller */
+	/* TF card */
+	sdhci@12530000 {
+		samsung,bus-width = <4>;
+		/*samsung,timing = <1 2 3>;*/
+		/*cd-gpios = <&gpk2 2 0>;*/
+		status = "okay";
+	};
+
+	/* eMMC */
+	dwmmc@12550000 {
+		samsung,bus-width = <8>;
+		samsung,timing = <2 1 0>;
+		samsung,removable = <0>;
+		fifoth_val = <0x203f0040>;
+		bus_hz = <400000000>;
+		div = <0x3>;
+		index = <4>;
+		status = "okay";
+	};
+
+	/* USB 2.0 Host Controller */
 	ehci@12580000 {
 		compatible = "samsung,exynos-ehci";
 		/* In order to reset USB ethernet */
@@ -140,22 +91,3 @@
 	};
 };
 
-/* TF card */
-&sdhci2 {
-    samsung,bus-width = <4>;
-    /* samsung,timing = <1 2 3>; */
-    /* cd-gpios = <&gpk2 2 0>; */
-    status = "okay";
-};
-
-/* EMMC */
-&mshc_0 {
-    samsung,bus-width = <8>;
-    samsung,timing = <2 1 0>;
-    samsung,removable = <0>;
-    fifoth_val = <0x203f0040>;
-    bus_hz = <400000000>;
-    div = <0x3>;
-    index = <4>;
-    status = "okay";
-};

--- a/drivers/usb/eth/Kconfig
+++ b/drivers/usb/eth/Kconfig
@@ -62,7 +62,7 @@ config USB_ETHER_SMSC95XX
 
 config USB_ETHER_DM9601
 	bool "DAVICOM DM9601 (USB 2.0) support"
-	depends on USB_HOST_ETHER
+	depends on USB_HOST_ETHER && DM_ETH
 	---help---
 	  Say Y here if you would like to support DAVICOM DM9601 based USB 2.0
 	  Ethernet Devices.

--- a/drivers/usb/eth/dm9601.c
+++ b/drivers/usb/eth/dm9601.c
@@ -17,7 +17,7 @@
 #include <linux/mii.h>
 #include "usb_ether.h"
 
-#define DEBUG
+// #define DEBUG
 #ifdef DEBUG
 #undef debug
 #define debug(fmt, args...) debug_cond(true, fmt, ##args)
@@ -37,38 +37,41 @@
 #define DM_WRITE_MEM	0x07
 
 /* registers */
-#define DM_NET_CTRL	0x00
-#define DM_RX_CTRL	0x05
+#define DM_NET_CTRL	    0x00
+#define DM_RX_CTRL	    0x05
 #define DM_SHARED_CTRL	0x0b
 #define DM_SHARED_ADDR	0x0c
 #define DM_SHARED_DATA	0x0d	/* low + high */
-#define DM_PHY_ADDR	0x10	    /* 6 bytes */
+#define DM_PHY_ADDR	    0x10	/* 6 bytes */
 #define DM_MCAST_ADDR	0x16	/* 8 bytes */
-#define DM_GPR_CTRL	0x1e
-#define DM_GPR_DATA	0x1f
-#define DM_CHIP_ID	0x2c
+#define DM_GPR_CTRL	    0x1e
+#define DM_GPR_DATA	    0x1f
+#define DM_CHIP_ID	    0x2c
 #define DM_MODE_CTRL	0x91	/* only on dm9620 */
 
 /* chip id values */
-#define ID_DM9601	0
-#define ID_DM9620	1
+#define ID_DM9601	    0
+#define ID_DM9620	    1
 
 #define DM_MAX_MCAST	64
 #define DM_MCAST_SIZE	8
 #define DM_EEPROM_LEN	256
 #define DM_TX_OVERHEAD	2	    /* 2 byte header */
 #define DM_RX_OVERHEAD	7	    /* 3 byte header + 4 byte crc tail */
-#define DM_TIMEOUT	1000
+#define DM_TIMEOUT	    1000
 
 /* local defines */
-#define USB_CTRL_SET_TIMEOUT 5000
-#define USB_CTRL_GET_TIMEOUT 5000
+#define USB_CTRL_SET_TIMEOUT  5000
+#define USB_CTRL_GET_TIMEOUT  5000
 #define USB_BULK_SEND_TIMEOUT 5000
 #define USB_BULK_RECV_TIMEOUT 5000
 
-#define DM9601_RX_URB_SIZE 2048
+#define DM9601_RX_URB_SIZE  2048
 #define PHY_CONNECT_TIMEOUT 5000
 
+#ifndef CONFIG_DM_ETH
+#error "this driver was based on DM_USB and DM_ETH, YOU DO NEED ENABLE them first"
+#endif
 /* driver private */
 struct dm9601_private {
     int flags;
@@ -83,16 +86,11 @@ static int dm_read(struct ueth_data *dev, u8 reg, u16 length, void *data)
 	int err;
     struct usb_device *usb_dev = dev->pusb_dev;
 
-	err = usb_control_msg(
-                          usb_dev,
-                          usb_rcvctrlpipe(usb_dev, 0),
-                          DM_READ_REGS,
-                          USB_DIR_IN | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
-                          0,
-                          reg,
-                          data,
-                          length,
-                          USB_CTRL_SET_TIMEOUT);
+	err = usb_control_msg(usb_dev, usb_rcvctrlpipe(usb_dev, 0),
+                    DM_READ_REGS,
+                    USB_DIR_IN | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
+                    0, reg, data, length,
+                    USB_CTRL_SET_TIMEOUT);
 	if(err != length && err >= 0)
 		err = -EINVAL;
 
@@ -109,13 +107,11 @@ static int dm_write(struct ueth_data *dev, u8 reg, u16 length, void *data)
 	int err;
     struct usb_device *usb_dev = dev->pusb_dev;
 
-    err = usb_control_msg(
-                          usb_dev,
-                          usb_sndctrlpipe(usb_dev, 0),
-                          DM_WRITE_REGS,
-                          USB_DIR_OUT | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
-                          0, reg, data, length,
-                          USB_CTRL_SET_TIMEOUT);
+    err = usb_control_msg(usb_dev, usb_sndctrlpipe(usb_dev, 0),
+                    DM_WRITE_REGS,
+                    USB_DIR_OUT | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
+                    0, reg, data, length,
+                    USB_CTRL_SET_TIMEOUT);
     if (err >= 0 && err < length)
         err = -EINVAL;
 
@@ -126,40 +122,16 @@ static int dm_write_reg(struct ueth_data *dev, u8 reg, u8 value)
 {
     struct usb_device *usb_dev = dev->pusb_dev;
 
-    return usb_control_msg(
-                           usb_dev,
-                           usb_sndctrlpipe(usb_dev, 0),
-                           DM_WRITE_REG,
-                           USB_DIR_OUT | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
-                           value,
-                           reg,
-                           NULL,
-                           0,
-                           USB_CTRL_SET_TIMEOUT
-                          );
+    return usb_control_msg(usb_dev, usb_sndctrlpipe(usb_dev, 0),
+                    DM_WRITE_REG,
+                    USB_DIR_OUT | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
+                    value, reg, NULL, 0,
+                    USB_CTRL_SET_TIMEOUT);
 }
-
-#if 0
-static void dm_write_async(struct usbnet *dev, u8 reg, u16 length, void *data)
-{
-	usbnet_write_cmd_async(dev, DM_WRITE_REGS,
-			       USB_DIR_OUT | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
-			       0, reg, data, length);
-}
-
-static void dm_write_reg_async(struct usbnet *dev, u8 reg, u8 value)
-{
-	usbnet_write_cmd_async(dev, DM_WRITE_REG,
-			       USB_DIR_OUT | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
-			       value, reg, NULL, 0);
-}
-#endif
 
 static int dm_read_shared_word(struct ueth_data *dev, int phy, u8 reg, __le16 *value)
 {
 	int ret, i;
-
-	/* mutex_lock(&dev->phy_mutex); */
 
 	dm_write_reg(dev, DM_SHARED_ADDR, phy ? (reg | 0x40) : reg);
 	dm_write_reg(dev, DM_SHARED_CTRL, phy ? 0xc : 0x4);
@@ -186,19 +158,16 @@ static int dm_read_shared_word(struct ueth_data *dev, int phy, u8 reg, __le16 *v
 	dm_write_reg(dev, DM_SHARED_CTRL, 0x0);
 	ret = dm_read(dev, DM_SHARED_DATA, 2, value);
 
-	debug("read shared %d 0x%02x returned 0x%04x, %d\n",
-		   phy, reg, *value, ret);
+	/* debug("read shared %d 0x%02x returned 0x%04x, %d\n", */
+	/* 	   phy, reg, *value, ret); */
 
  out:
-	/* mutex_unlock(&dev->phy_mutex); */
 	return ret;
 }
 
 static int dm_write_shared_word(struct ueth_data *dev, int phy, u8 reg, __le16 value)
 {
 	int ret, i;
-
-	/* mutex_lock(&dev->phy_mutex); */
 
 	ret = dm_write(dev, DM_SHARED_DATA, 2, &value);
 	if (ret < 0)
@@ -229,17 +198,15 @@ static int dm_write_shared_word(struct ueth_data *dev, int phy, u8 reg, __le16 v
 	dm_write_reg(dev, DM_SHARED_CTRL, 0x0);
 
 out:
-	/* mutex_unlock(&dev->phy_mutex); */
 	return ret;
 }
 
+/* no need these set for now */
 #if 0
 static int dm_read_eeprom_word(struct usbnet *dev, u8 offset, void *value)
 {
 	return dm_read_shared_word(dev, 0, offset, value);
 }
-
-
 
 static int dm9601_get_eeprom_len(struct net_device *dev)
 {
@@ -268,80 +235,40 @@ static int dm9601_get_eeprom(struct net_device *net,
 
 static int dm9601_mdio_read(struct ueth_data *dev, int phy_id, int loc)
 {
-    /* TODO: need ALLOC_CACHE_ALIGN_BUFFER ? */
-	__le16 res;
+    ALLOC_CACHE_ALIGN_BUFFER(__le16, res, 1);
 
 	if (phy_id) {
 		printf("Only internal phy supported\n");
 		return 0;
 	}
 
-	dm_read_shared_word(dev, 1, loc, &res);
+	dm_read_shared_word(dev, 1, loc, res);
 
-    debug(
-          "dm9601_mdio_read() phy_id=0x%02x, loc=0x%02x, returns=0x%04x\n",
-          phy_id, loc, le16_to_cpu(res));
+    /* debug( "dm9601_mdio_read() phy_id=0x%02x, loc=0x%02x, returns=0x%04x\n", */
+    /*       phy_id, loc, le16_to_cpu(res)); */
 
-	return le16_to_cpu(res);
+	return le16_to_cpu(*res);
 }
 
-static void dm9601_mdio_write(struct ueth_data *dev, int phy_id, int loc,
-			      int val)
+static void dm9601_mdio_write(struct ueth_data *dev, int phy_id, int loc, int val)
 {
-	__le16 res = cpu_to_le16(val);
+    ALLOC_CACHE_ALIGN_BUFFER(__le16, res, 1);
+	*res = cpu_to_le16(val);
 
 	if (phy_id) {
 		printf("Only internal phy supported\n");
 		return;
 	}
 
-	debug("dm9601_mdio_write() phy_id=0x%02x, loc=0x%02x, val=0x%04x\n",
-		   phy_id, loc, val);
+	/* debug("dm9601_mdio_write() phy_id=0x%02x, loc=0x%02x, val=0x%04x\n", */
+	/* 	   phy_id, loc, val); */
 
-	dm_write_shared_word(dev, 1, loc, res);
+	dm_write_shared_word(dev, 1, loc, *res);
 }
-
-#if 0
-static void dm9601_get_drvinfo(struct net_device *net,
-			       struct ethtool_drvinfo *info)
-{
-	/* Inherit standard device info */
-	usbnet_get_drvinfo(net, info);
-}
-
-static u32 dm9601_get_link(struct net_device *net)
-{
-	struct usbnet *dev = netdev_priv(net);
-
-	return mii_link_ok(&dev->mii);
-}
-
-static int dm9601_ioctl(struct net_device *net, struct ifreq *rq, int cmd)
-{
-	struct usbnet *dev = netdev_priv(net);
-
-	return generic_mii_ioctl(&dev->mii, if_mii(rq), cmd, NULL);
-}
-
-static const struct ethtool_ops dm9601_ethtool_ops = {
-	.get_drvinfo	= dm9601_get_drvinfo,
-	.get_link	= dm9601_get_link,
-	.get_msglevel	= usbnet_get_msglevel,
-	.set_msglevel	= usbnet_set_msglevel,
-	.get_eeprom_len	= dm9601_get_eeprom_len,
-	.get_eeprom	= dm9601_get_eeprom,
-	.nway_reset	= usbnet_nway_reset,
-	.get_link_ksettings	= usbnet_get_link_ksettings,
-	.set_link_ksettings	= usbnet_set_link_ksettings,
-};
-#endif
 
 static void dm9601_set_multicast(struct ueth_data *dev)
 {
-	/* We use the 20 byte dev->data for our 8 byte filter buffer
-	 * to avoid allocating memory that is tricky to free later */
     ALLOC_CACHE_ALIGN_BUFFER(unsigned char, hashes, DM_MCAST_SIZE);
-	/* u8 *hashes = (u8 *) & dev->data; */
 	u8 rx_ctl = 0x31;
 
 	memset(hashes, 0x00, DM_MCAST_SIZE);
@@ -384,11 +311,6 @@ static int dm9601_read_mac_address(struct ueth_data *dev, uint8_t *enetaddr)
 }
 
 
-static void __dm9601_set_mac_address(struct ueth_data *dev, void *addr)
-{
-	dm_write(dev, DM_PHY_ADDR, ETH_ALEN, addr);
-}
-
 static int dm9601_set_mac_address(struct ueth_data *dev, uint8_t *enetaddr)
 {
     ALLOC_CACHE_ALIGN_BUFFER(unsigned char, addr, ETH_ALEN);
@@ -399,9 +321,9 @@ static int dm9601_set_mac_address(struct ueth_data *dev, uint8_t *enetaddr)
 	}
 
 	memcpy(addr, enetaddr, ETH_ALEN);
-	__dm9601_set_mac_address(dev, addr);
+	dm_write(dev, DM_PHY_ADDR, ETH_ALEN, addr);
 
-#if 1
+#ifdef DEBUG
     dm9601_read_mac_address(dev, addr);
     debug("---->after write: <%02x:%02x:%02x:%02x:%02x:%02x>\n",
           addr[0], addr[1], addr[2],
@@ -433,20 +355,6 @@ static int mii_nway_restart(struct ueth_data *dev)
     return r;
 }
 
-#if 0
-static const struct net_device_ops dm9601_netdev_ops = {
-	.ndo_open		= usbnet_open,
-	.ndo_stop		= usbnet_stop,
-	.ndo_start_xmit		= usbnet_start_xmit,
-	.ndo_tx_timeout		= usbnet_tx_timeout,
-	.ndo_change_mtu		= usbnet_change_mtu,
-	.ndo_get_stats64	= usbnet_get_stats64,
-	.ndo_validate_addr	= eth_validate_addr,
-	.ndo_do_ioctl 		= dm9601_ioctl,
-	.ndo_set_rx_mode	= dm9601_set_multicast,
-	.ndo_set_mac_address	= dm9601_set_mac_address,
-};
-#endif
 
 static int dm9601_init(struct ueth_data *dev)
 {
@@ -455,15 +363,14 @@ static int dm9601_init(struct ueth_data *dev)
 
 	debug("\n----> %s()\n", __func__);
 
-    /* mii_nway_restart(dev); */
+    mii_nway_restart(dev);
     /*dm_set_autoneg(dev);*/
 
     /* dm9601_link_reset(dev); */
 
 #define TIMEOUT_RESOLUTION 50   /* ms */
     do {
-        link_detected = dm9601_mdio_read(dev, dev->phy_id, MII_BMSR) &
-            BMSR_LSTATUS;
+        link_detected = dm9601_mdio_read(dev, dev->phy_id, MII_BMSR) & BMSR_LSTATUS;
         if (!link_detected) {
             if (timeout == 0)
                 printf("Waiting for Ethernet connection... ");
@@ -491,6 +398,7 @@ out_err:
     return -1;
 
 }
+
 static int dm9601_bind(struct udevice *udev)
 {
 	int ret = 0;
@@ -499,29 +407,6 @@ static int dm9601_bind(struct udevice *udev)
     struct eth_pdata *pdata = dev_get_platdata(udev);
     struct dm9601_private *priv = dev_get_priv(udev);
     struct ueth_data *dev = &priv->ueth;
-
-#if 0
-	ret = usbnet_get_endpoints(dev, intf);
-	if (ret)
-		goto out;
-
-	dev->net->netdev_ops = &dm9601_netdev_ops;
-	dev->net->ethtool_ops = &dm9601_ethtool_ops;
-	dev->net->hard_header_len += DM_TX_OVERHEAD;
-	dev->hard_mtu = dev->net->mtu + dev->net->hard_header_len;
-
-	/* dm9620/21a require room for 4 byte padding, even in dm9601
-	 * mode, so we need +1 to be able to receive full size
-	 * ethernet frames.
-	 */
-	dev->rx_urb_size = dev->net->mtu + ETH_HLEN + DM_RX_OVERHEAD + 1;
-
-	dev->mii.dev = dev->net;
-	dev->mii.mdio_read = dm9601_mdio_read;
-	dev->mii.mdio_write = dm9601_mdio_write;
-	dev->mii.phy_id_mask = 0x1f;
-	dev->mii.reg_num_mask = 0x1f;
-#endif
 
 	/* reset */
 	dm_write_reg(dev, DM_NET_CTRL, 1);
@@ -534,6 +419,13 @@ static int dm9601_bind(struct udevice *udev)
 		goto out;
 	}
 
+#if 1
+    const u8 mac_addr[6] = {0x00, 0xD8, 0x1C, 0x04, 0x55, 0x60};
+    debug("--->set mac addr!\n");
+    dm9601_set_mac_address(dev, (u8 *)mac_addr);
+    memcpy(mac, mac_addr, 6);
+#endif
+
 	/*
 	 * Overwrite the auto-generated address only with good ones.
 	 */
@@ -541,8 +433,9 @@ static int dm9601_bind(struct udevice *udev)
 		memcpy(pdata->enetaddr, mac, ETH_ALEN);
 	else {
 		printf("dm9601: No valid MAC address in EEPROM, using %pM\n", mac);
-		/* __dm9601_set_mac_address(mac); */
+		/* dm9601_set_mac_address(dev, mac); */
 	}
+
 
 	if (dm_read_reg(dev, DM_CHIP_ID, &id) < 0) {
 		printf("Error reading chip ID\n");
@@ -581,117 +474,6 @@ out:
 }
 
 #if 0
-static int dm9601_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
-{
-	u8 status;
-	int len;
-
-	/* format:
-	   b1: rx status
-	   b2: packet length (incl crc) low
-	   b3: packet length (incl crc) high
-	   b4..n-4: packet data
-	   bn-3..bn: ethernet crc
-	 */
-
-	if (unlikely(skb->len < DM_RX_OVERHEAD)) {
-		dev_err(&dev->udev->dev, "unexpected tiny rx frame\n");
-		return 0;
-	}
-
-	status = skb->data[0];
-	len = (skb->data[1] | (skb->data[2] << 8)) - 4;
-
-	if (unlikely(status & 0xbf)) {
-		if (status & 0x01) dev->net->stats.rx_fifo_errors++;
-		if (status & 0x02) dev->net->stats.rx_crc_errors++;
-		if (status & 0x04) dev->net->stats.rx_frame_errors++;
-		if (status & 0x20) dev->net->stats.rx_missed_errors++;
-		if (status & 0x90) dev->net->stats.rx_length_errors++;
-		return 0;
-	}
-
-	skb_pull(skb, 3);
-	skb_trim(skb, len);
-
-	return 1;
-}
-
-static struct sk_buff *dm9601_tx_fixup(struct usbnet *dev, struct sk_buff *skb,
-				       gfp_t flags)
-{
-	int len, pad;
-
-	/* format:
-	   b1: packet length low
-	   b2: packet length high
-	   b3..n: packet data
-	*/
-
-	len = skb->len + DM_TX_OVERHEAD;
-
-	/* workaround for dm962x errata with tx fifo getting out of
-	 * sync if a USB bulk transfer retry happens right after a
-	 * packet with odd / maxpacket length by adding up to 3 bytes
-	 * padding.
-	 */
-	while ((len & 1) || !(len % dev->maxpacket))
-		len++;
-
-	len -= DM_TX_OVERHEAD; /* hw header doesn't count as part of length */
-	pad = len - skb->len;
-
-	if (skb_headroom(skb) < DM_TX_OVERHEAD || skb_tailroom(skb) < pad) {
-		struct sk_buff *skb2;
-
-		skb2 = skb_copy_expand(skb, DM_TX_OVERHEAD, pad, flags);
-		dev_kfree_skb_any(skb);
-		skb = skb2;
-		if (!skb)
-			return NULL;
-	}
-
-	__skb_push(skb, DM_TX_OVERHEAD);
-
-	if (pad) {
-		memset(skb->data + skb->len, 0, pad);
-		__skb_put(skb, pad);
-	}
-
-	skb->data[0] = len;
-	skb->data[1] = len >> 8;
-
-	return skb;
-}
-
-static void dm9601_status(struct usbnet *dev, struct urb *urb)
-{
-	int link;
-	u8 *buf;
-
-	/* format:
-	   b0: net status
-	   b1: tx status 1
-	   b2: tx status 2
-	   b3: rx status
-	   b4: rx overflow
-	   b5: rx count
-	   b6: tx count
-	   b7: gpr
-	*/
-
-	if (urb->actual_length < 8)
-		return;
-
-	buf = urb->transfer_buffer;
-
-	link = !!(buf[0] & 0x40);
-	if (netif_carrier_ok(dev->net) != link) {
-		usbnet_link_change(dev, link, 1);
-		netdev_dbg(dev->net, "Link Status is: %d\n", link);
-	}
-}
-
 static int dm9601_link_reset(struct usbnet *dev)
 {
 	struct ethtool_cmd ecmd = { .cmd = ETHTOOL_GSET };
@@ -706,8 +488,33 @@ static int dm9601_link_reset(struct usbnet *dev)
 }
 #endif
 
-/* FIXME: those not valid */
-static const unsigned long dm9601_info;
+/*
+ * dump_msg() - dump content of memory to hex
+ * @ptr:    start address of memory to dump
+ * @len:    number of bytes to dump
+ */
+static void dump_msg(uint8_t *ptr, int len)
+{
+    int i = 0, j = 0;
+
+    debug("Dump:\n");
+    for (i = 0; i < len; i++) {
+        debug("%02x ", ptr[i]);
+
+        if((i + 1) % 8 == 0) {
+            debug(" ");
+        }
+        if ((i + 1) % 16 == 0) {
+            debug("\n");
+            j = i + 1;
+        }
+    }
+
+    if(j < i) {
+        debug("\n");
+    }
+}
+
 
 #ifdef CONFIG_DM_ETH
 static int dm9601_eth_start(struct udevice *udev)
@@ -727,19 +534,110 @@ void dm9601_eth_stop(struct udevice *udev)
 
 int dm9601_eth_send(struct udevice *udev, void *packet, int length)
 {
+    int err;
+    u16 packet_len;
+    int actual_len;
     struct dm9601_private *priv = dev_get_priv(udev);
     struct ueth_data *dev = &priv->ueth;
+    struct usb_device *usb_dev = dev->pusb_dev;
+    ALLOC_CACHE_ALIGN_BUFFER(unsigned char, msg, PKTSIZE + DM_TX_OVERHEAD);
 
 	debug("\n----> %s()\n", __func__);
 
+	/* format:
+	   b1: packet length low
+	   b2: packet length high
+	   b3..n: packet data
+	*/
+
+    packet_len = length;
+    cpu_to_le16s(&packet_len);
+
+    memcpy(msg, &packet_len, DM_TX_OVERHEAD);
+    memcpy(msg + DM_TX_OVERHEAD, (void *)packet, length);
+
+    err = usb_bulk_msg(usb_dev,
+                       usb_sndbulkpipe(usb_dev, dev->ep_out),
+                       (void *)msg,
+                       length + sizeof(packet_len),
+                       &actual_len,
+                       USB_BULK_SEND_TIMEOUT);
+    debug("Tx: len = %u, actual = %u, err = %d\n",
+          length + sizeof(packet_len), actual_len, err);
+
+    dump_msg(msg, actual_len);
+    dump_msg(msg + 2, actual_len - 2);
+
+    return err;
     /* return dm9601_send(dev, packet, length); */
-    return 0;
 }
 
 int dm9601_eth_recv(struct udevice *udev, int flags, uchar **packetp)
 {
+    struct dm9601_private *priv = dev_get_priv(udev);
+    struct ueth_data *ueth = &priv->ueth;
+    uint8_t *ptr;
+    int ret = 0;
+    int len = 0;
+    uint8_t status = 0;
+    uint16_t packet_len = 0;
+    ALLOC_CACHE_ALIGN_BUFFER(unsigned char, pkt, PKTSIZE);
+
 	debug("\n----> %s()\n", __func__);
-    return 0;
+
+    len = usb_ether_get_rx_bytes(ueth, &ptr);
+    debug("----> %s: first try, len=%d\n", __func__, len);
+    if (!len) {
+        if (!(flags & ETH_RECV_CHECK_DEVICE))
+            return -EAGAIN;
+        ret = usb_ether_receive(ueth, DM9601_RX_URB_SIZE);
+        if (ret == -EAGAIN)
+            return ret;
+
+        len = usb_ether_get_rx_bytes(ueth, &ptr);
+        debug("---->%s: second try, len=%d\n", __func__, len);
+    }
+
+    debug("---->Rx: len = %u, actual = %u, err = %d\n", DM9601_RX_URB_SIZE, len, ret);
+    dump_msg(ptr, len);
+    dump_msg(ptr + 3, len - 3);
+
+	/* format:
+	   b1: rx status
+	   b2: packet length (incl crc) low
+	   b3: packet length (incl crc) high
+	   b4..n-4: packet data
+	   bn-3..bn: ethernet crc
+	 */
+
+    if (len < DM_RX_OVERHEAD) {
+        debug("Rx: incomplete packet length\n");
+        goto err;
+    }
+
+    status = ptr[0];
+    if (unlikely(status & 0xbf)) {
+        printf("Rx: packet status failure: %d\n", status);
+        goto err;
+    }
+
+    /* real data length, need sub 4 bytes crc tail */
+    packet_len = (ptr[1] | (ptr[2] << 8)) - 4;
+    if (packet_len > len - DM_RX_OVERHEAD) {
+        debug("Rx: too large packet: %d\n", packet_len);
+        goto err;
+    }
+
+    debug("---> packet_len = %d, len = %d\n", packet_len, len);
+    memcpy(pkt, ptr + 3, packet_len);
+    /* *packetp = ptr + sizeof(status) + sizeof(packet_len); */
+    *packetp = pkt;
+    return packet_len;
+
+err:
+    /* drop all in buffer */
+    usb_ether_advance_rxbuf(ueth, -1);
+    return -EINVAL;
 }
 
 static int dm9601_free_pkt(struct udevice *udev, uchar *packet, int packet_len)
@@ -749,9 +647,8 @@ static int dm9601_free_pkt(struct udevice *udev, uchar *packet, int packet_len)
 
 	debug("\n----> %s()\n", __func__);
 
-    /* TODO: check this */
-    packet_len = ALIGN(packet_len, 4);
-    usb_ether_advance_rxbuf(dev, sizeof(u32) + packet_len);
+    packet_len = ALIGN(packet_len, 2);
+    usb_ether_advance_rxbuf(dev, DM_RX_OVERHEAD + packet_len);
 
     return 0;
 }
@@ -820,34 +717,20 @@ U_BOOT_DRIVER(dm9601_eth) = {
 };
 
 static const struct usb_device_id dm9601_eth_id_table[] = {
-    /* Corega FEther USB-TXC */
-	{ USB_DEVICE(0x07aa, 0x9601), .driver_info = (unsigned long)&dm9601_info, },
-    /* Davicom USB-100 */
-	{ USB_DEVICE(0x0a46, 0x9601), .driver_info = (unsigned long)&dm9601_info, },
-    /* ZT6688 USB NIC */
-	{ USB_DEVICE(0x0a46, 0x6688), .driver_info = (unsigned long)&dm9601_info, },
-    /* ShanTou ST268 USB NIC */
-	{ USB_DEVICE(0x0a46, 0x0268), .driver_info = (unsigned long)&dm9601_info, },
-    /* ADMtek ADM8515 USB NIC */
-	{ USB_DEVICE(0x0a46, 0x8515), .driver_info = (unsigned long)&dm9601_info, },
-    /* Hirose USB-100 */
-	{ USB_DEVICE(0x0a47, 0x9601), .driver_info = (unsigned long)&dm9601_info, },
-	/* DM9601 USB to Fast Ethernet Adapter */
-	{ USB_DEVICE(0x0fe6, 0x8101), .driver_info = (unsigned long)&dm9601_info, },
-	/* DM9601 USB to Fast Ethernet Adapter */
-	{ USB_DEVICE(0x0fe6, 0x9700), .driver_info = (unsigned long)&dm9601_info, },
-	/* DM9000E */
-	{ USB_DEVICE(0x0a46, 0x9000), .driver_info = (unsigned long)&dm9601_info, },
-	/* DM9620 USB to Fast Ethernet Adapter */
-	{ USB_DEVICE(0x0a46, 0x9620), .driver_info = (unsigned long)&dm9601_info, },
-	/* DM9621A USB to Fast Ethernet Adapter */
-	{ USB_DEVICE(0x0a46, 0x9621), .driver_info = (unsigned long)&dm9601_info, },
-	/* DM9622 USB to Fast Ethernet Adapter */
-	{ USB_DEVICE(0x0a46, 0x9622), .driver_info = (unsigned long)&dm9601_info, },
-	/* DM962OA USB to Fast Ethernet Adapter */
-	{ USB_DEVICE(0x0a46, 0x0269), .driver_info = (unsigned long)&dm9601_info, },
-	/* DM9621A USB to Fast Ethernet Adapter */
-	{ USB_DEVICE(0x0a46, 0x1269), .driver_info = (unsigned long)&dm9601_info, },
+	{ USB_DEVICE(0x07aa, 0x9601), },    /* Corega FEther USB-TXC */
+	{ USB_DEVICE(0x0a46, 0x9601), },    /* Davicom USB-100 */
+	{ USB_DEVICE(0x0a46, 0x6688), },    /* ZT6688 USB NIC */
+	{ USB_DEVICE(0x0a46, 0x0268), },    /* ShanTou ST268 USB NIC */
+	{ USB_DEVICE(0x0a46, 0x8515), },    /* ADMtek ADM8515 USB NIC */
+	{ USB_DEVICE(0x0a47, 0x9601), },    /* Hirose USB-100 */
+	{ USB_DEVICE(0x0fe6, 0x8101), },	/* DM9601 USB to Fast Ethernet Adapter */
+	{ USB_DEVICE(0x0fe6, 0x9700), },	/* DM9601 USB to Fast Ethernet Adapter */
+	{ USB_DEVICE(0x0a46, 0x9000), },	/* DM9000E */
+	{ USB_DEVICE(0x0a46, 0x9620), },	/* DM9620 USB to Fast Ethernet Adapter */
+	{ USB_DEVICE(0x0a46, 0x9621), },	/* DM9621A USB to Fast Ethernet Adapter */
+	{ USB_DEVICE(0x0a46, 0x9622), },	/* DM9622 USB to Fast Ethernet Adapter */
+	{ USB_DEVICE(0x0a46, 0x0269), },	/* DM962OA USB to Fast Ethernet Adapter */
+	{ USB_DEVICE(0x0a46, 0x1269), },	/* DM9621A USB to Fast Ethernet Adapter */
 	{},			// END
 };
 

--- a/drivers/usb/eth/dm9601.c
+++ b/drivers/usb/eth/dm9601.c
@@ -363,9 +363,8 @@ static int dm9601_init(struct ueth_data *dev)
 
 	debug("\n----> %s()\n", __func__);
 
-    mii_nway_restart(dev);
+    /* mii_nway_restart(dev); */
     /*dm_set_autoneg(dev);*/
-
     /* dm9601_link_reset(dev); */
 
 #define TIMEOUT_RESOLUTION 50   /* ms */
@@ -569,7 +568,6 @@ int dm9601_eth_send(struct udevice *udev, void *packet, int length)
     dump_msg(msg + 2, actual_len - 2);
 
     return err;
-    /* return dm9601_send(dev, packet, length); */
 }
 
 int dm9601_eth_recv(struct udevice *udev, int flags, uchar **packetp)
@@ -629,8 +627,9 @@ int dm9601_eth_recv(struct udevice *udev, int flags, uchar **packetp)
     }
 
     debug("---> packet_len = %d, len = %d\n", packet_len, len);
-    memcpy(pkt, ptr + 3, packet_len);
-    /* *packetp = ptr + sizeof(status) + sizeof(packet_len); */
+    memcpy(pkt, ptr + 3, packet_len);   /* 3 bytes header */
+
+    /* must return aligned memory */
     *packetp = pkt;
     return packet_len;
 

--- a/include/configs/itop4412.h
+++ b/include/configs/itop4412.h
@@ -75,7 +75,10 @@
 	"env import -t $loadaddr $filesize\0" \
     "loadbootscript=load mmc ${mmcdev} ${loadaddr} boot.scr\0" \
     "bootscript=echo Running bootscript from mmc${mmcdev} ...; " \
-    "source ${loadaddr}\0"
+    "source ${loadaddr}\0" \
+    "ethaddr=00:D8:1C:04:55:60\0" \
+    "ipaddr=192.168.1.141\0" \
+    "serverip=192.168.1.140\0"
 #define CONFIG_BOOTCOMMAND \
 	"if mmc rescan; then " \
 		"echo SD/MMC found on device ${mmcdev};" \


### PR DESCRIPTION
Here are Instructions to use net. MUST call these before use `ping` or `tftpboot`
- usb start
- usb reset

After instruction above has been executed, you will see message as below.
```
u-boot # usb start
starting USB...
USB0:   USB EHCI 1.00
scanning bus 0 for devices... 1 USB Device(s) found
u-boot # usb reset
resetting USB...
USB0:   USB EHCI 1.00
scanning bus 0 for devices... 3 USB Device(s) found
u-boot # 

```
Now, you can use `tftpboot` to load kernel, initrd, dtb from network and other network command,  etc.